### PR TITLE
fix(build): disable maven shade plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,6 +132,12 @@
     <build>
         <plugins>
             <plugin>
+                <artifactId>maven-shade-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>io.micronaut.maven</groupId>
                 <artifactId>micronaut-maven-plugin</artifactId>
             </plugin>


### PR DESCRIPTION
this configures compiled jar to be not-a-fat-jar

Signed-off-by: jonathan zollinger <jonathan.zollinger@outlook.com>
