### PR TITLE
Add scheduled job for Maven tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,8 @@
 name: Run Maven Tests
 
 on:
+  schedule:
+    - cron: "0 10 * * 1"
   push:
     branches:
     - main


### PR DESCRIPTION
Added a scheduled job to run Maven tests every Monday at 10 AM.

<!-- Thanks for submitting a PR! -->
## Purpose of this Pull Request
<!-- ie 'addresses issue #7689075'. Be sure to preface the pr title appropriately with this purpose in mind -->
enable tests to run consistently despite edit frequency.

## How does this Pull Request address its purpose?
<!-- how are your code changes pertinent to this PR's goal? -->
adds a cron job element to the test workflow, set to run on mondays.

## Iterate what tests have been added to maintain complete code coverage. 
<!-- ie 'unit tests for the new "BatCarLocation" class are added in the new test class of the same name' -->
No tests are added, this affects CI only


<!-- note: the sign of consistently well written pull requests are ones that don't require further discussion from 
    reviewers. Make everything the reviewer will want to see prior to approval easy to find and easy to 
    understand your rationale -->